### PR TITLE
Add new `require_data` field in component protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ class Components::Users::ProfileResume
 
   content do
     name Taksi::Dynamic
+    profile_kind Taksi::Static, 'resume'
 
     details do
       age Taksi::Dynamic
@@ -69,8 +70,10 @@ Which provide us:
     {
       "name": "users/profile_resume",
       "identifier": "component$0",
+      "requires_data": true,
       "content": {
         "name": null,
+        "profile_kind": "resume",
         "details": {
           "age": null,
           "email": null

--- a/lib/taksi.rb
+++ b/lib/taksi.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'singleton'
+require 'forwardable'
 
 require 'taksi/version'
 

--- a/lib/taksi/component.rb
+++ b/lib/taksi/component.rb
@@ -1,6 +1,18 @@
 # frozen_string_literal: true
 
 module Taksi
+  # A custom module to turn a class into a component on taksi protocol
+  #
+  # ```ruby
+  #   class CustomComponent
+  #     include Taksi::Component.new('customs/component_name')
+  #
+  #     content do
+  #       field_name Taksi::Static
+  #     end
+  #   end
+  # ```
+  #
   class Component < ::Module
     attr_reader :identifier
 

--- a/lib/taksi/components/field.rb
+++ b/lib/taksi/components/field.rb
@@ -10,7 +10,9 @@ module Taksi
         @name = name.to_sym
         @parent = parent
 
-        raise 'You must provide a value or a block definition to build field' unless args.size.positive? || block_given?
+        raise <<~MESSAGE unless args.size.positive? || block_given?
+          You must provide a value or a block definition to build field
+        MESSAGE
 
         @value = args.shift.new(skeleton, name, *args) if args.size.positive?
         @nested_fields = []

--- a/lib/taksi/components/skeleton.rb
+++ b/lib/taksi/components/skeleton.rb
@@ -9,6 +9,8 @@ module Taksi
         @parent = parent
         @name = name
 
+        raise 'To build a component you need to provide a `content` block' unless block_given?
+
         @content = ::Taksi::Components::Field.new(self, :content, &block)
       end
 
@@ -20,10 +22,15 @@ module Taksi
         content.fields
       end
 
+      def dynamic?
+        @content.dynamic?
+      end
+
       def as_json
         {
           name: name,
-          identifier: id
+          identifier: id,
+          requires_data: dynamic?
         }.tap do |json|
           json.merge!(content.as_json)
         end

--- a/lib/taksi/interface.rb
+++ b/lib/taksi/interface.rb
@@ -36,7 +36,7 @@ module Taksi
       attr_reader :skeleton
 
       def find(version, alternative = nil)
-        ::Taksi::Registry.find(interface_name, version, alternative)
+        ::Taksi::Registry.find(@interface_definition.interface_name, version, alternative)
       end
 
       def initiate(interface_definition)

--- a/lib/taksi/interface.rb
+++ b/lib/taksi/interface.rb
@@ -1,9 +1,17 @@
 # frozen_string_literal: true
 
 module Taksi
+  # A custom module that turns a class into a interface on taksi protocol
+  #
   class Interface < ::Module
     attr_reader :interface_name, :version_pattern, :alternatives
 
+    # Finds for a interface by its name and the current version
+    # @param name [String]
+    # @param version [String] just like '0.2.1'
+    # @param alternatives: [Array]
+    # @raises`::Taksi::Registry::InterfaceNotFoundError`
+    # @return Class the class of interface
     def self.find(name, version, alternative: nil)
       ::Taksi::Registry.find(name, version, alternative)
     end

--- a/lib/taksi/registry.rb
+++ b/lib/taksi/registry.rb
@@ -40,7 +40,7 @@ module Taksi
 
         next true if alternative.nil?
 
-        next true if interface.alternatives.blank?
+        next true if interface.alternatives.nil?
 
         next true if interface.alternatives.include?(alternative)
 

--- a/lib/taksi/registry.rb
+++ b/lib/taksi/registry.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'forwardable'
 module Taksi
   class Registry
     include ::Singleton

--- a/spec/lib/component_spec.rb
+++ b/spec/lib/component_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe ::Taksi::Component do
   before do
     class DummyComponent
       include ::Taksi::Component.new('dummy/component')
+
+      content { }
     end
 
     class DummyInterface
@@ -36,6 +38,7 @@ RSpec.describe ::Taksi::Component do
       expect(subject.skeleton.as_json).to eq({
                                                name: 'dummy/component',
                                                identifier: 'component$0',
+                                               requires_data: false,
                                                content: {}
                                              })
     end
@@ -57,6 +60,7 @@ RSpec.describe ::Taksi::Component do
       expect(subject.skeleton.as_json).to eq({
                                                name: 'dummy/component',
                                                identifier: 'component$0',
+                                               requires_data: true,
                                                content: {
                                                  type: 'dummy_static_value',
                                                  title: nil
@@ -84,6 +88,7 @@ RSpec.describe ::Taksi::Component do
       expect(subject.skeleton.as_json).to eq({
                                                name: 'dummy/component',
                                                identifier: 'component$0',
+                                               requires_data: true,
                                                content: {
                                                  title: nil,
                                                  nested: {

--- a/spec/lib/component_spec.rb
+++ b/spec/lib/component_spec.rb
@@ -78,6 +78,10 @@ RSpec.describe ::Taksi::Component do
           nested do
             type ::Taksi::Static, 'dummy_static_value'
             title ::Taksi::Dynamic, 'dynamic_value.path'
+
+            too_nested do
+              again ::Taksi::Static, 'dummy_static_value'
+            end
           end
         end
       end
@@ -93,7 +97,10 @@ RSpec.describe ::Taksi::Component do
                                                  title: nil,
                                                  nested: {
                                                    type: 'dummy_static_value',
-                                                   title: nil
+                                                   title: nil,
+                                                   too_nested: {
+                                                    again: 'dummy_static_value',
+                                                   }
                                                  }
                                                }
                                              })

--- a/spec/lib/component_spec.rb
+++ b/spec/lib/component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ::Taksi::Component do
     class DummyComponent
       include ::Taksi::Component.new('dummy/component')
 
-      content { }
+      content {}
     end
 
     class DummyInterface
@@ -99,7 +99,7 @@ RSpec.describe ::Taksi::Component do
                                                    type: 'dummy_static_value',
                                                    title: nil,
                                                    too_nested: {
-                                                    again: 'dummy_static_value',
+                                                     again: 'dummy_static_value'
                                                    }
                                                  }
                                                }

--- a/spec/lib/components/field_spec.rb
+++ b/spec/lib/components/field_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ::Taksi::Components::Field do
   subject { described_class.new(skeleton, key, *argument) }
 
   let(:interface_skeleton) { ::Taksi::Interfaces::Skeleton.new }
-  let(:skeleton) { interface_skeleton.create_component('dummy_component') }
+  let(:skeleton) { interface_skeleton.create_component('dummy_component') {  } }
   let(:key) { :dummy }
 
   context 'when with static fields' do

--- a/spec/lib/components/field_spec.rb
+++ b/spec/lib/components/field_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ::Taksi::Components::Field do
   subject { described_class.new(skeleton, key, *argument) }
 
   let(:interface_skeleton) { ::Taksi::Interfaces::Skeleton.new }
-  let(:skeleton) { interface_skeleton.create_component('dummy_component') {  } }
+  let(:skeleton) { interface_skeleton.create_component('dummy_component') {} }
   let(:key) { :dummy }
 
   context 'when with static fields' do

--- a/spec/lib/interface_spec.rb
+++ b/spec/lib/interface_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ::Taksi::Interface do
     end
 
     class DummyInterface
-      include ::Taksi::Interface.new('dummy-interface', '> 1.0')
+      include ::Taksi::Interface.new('dummy-interface', '~> 1.0')
 
       add DummyComponent, with: :dummy_data
 
@@ -38,6 +38,80 @@ RSpec.describe ::Taksi::Interface do
     context 'when interface do not exists' do
       it 'raises an error' do
         expect { described_class.find('dummy-interface', '0.3') }.to raise_error(Taksi::Registry::InterfaceNotFoundError)
+      end
+    end
+
+    context 'when using interface shortcut' do
+      before do
+        class DummyInterfaceV2
+          include ::Taksi::Interface.new('dummy-interface', '~> 2.0')
+
+          add DummyComponent, with: :dummy_data
+
+          def dummy_data
+            {title: 'dummy_value'}
+          end
+        end
+      end
+
+      after do
+        Object.send(:remove_const, :DummyInterfaceV2)
+      end
+
+      it 'finds same interface but in other version' do
+        expect(DummyInterface.find('2.3')).to eq(DummyInterfaceV2)
+        expect(described_class.find('dummy-interface', '2.3')).to eq(DummyInterfaceV2)
+      end
+    end
+
+    context 'when looking for an alternative' do
+      before do
+        class DummyInterfaceV2
+          include ::Taksi::Interface.new('dummy-interface', '~> 2.0', alternatives: ['A', 'B'])
+
+          add DummyComponent, with: :dummy_data
+
+          def dummy_data
+            {title: 'dummy_value'}
+          end
+        end
+
+        class DummyInterfaceV2Other
+          include ::Taksi::Interface.new('dummy-interface', '~> 2.0', alternatives: ['C'])
+
+          add DummyComponent, with: :dummy_data
+
+          def dummy_data
+            {title: 'dummy_value'}
+          end
+        end
+      end
+
+      after do
+        Object.send(:remove_const, :DummyInterfaceV2)
+        Object.send(:remove_const, :DummyInterfaceV2Other)
+      end
+
+      it 'finds same interface but in other version' do
+        expect(DummyInterface.find('2.3', 'A')).to eq(DummyInterfaceV2)
+        expect(described_class.find('dummy-interface', '2.3', alternative: 'A')).to eq(DummyInterfaceV2)
+        expect(DummyInterfaceV2Other.find('2.3', 'A')).to eq(DummyInterfaceV2)
+        expect(DummyInterfaceV2.find('2.3', 'C')).to eq(DummyInterfaceV2Other)
+        expect(DummyInterface.find('2.3', 'C')).to eq(DummyInterfaceV2Other)
+        expect(described_class.find('dummy-interface', '2.3', alternative: 'C')).to eq(DummyInterfaceV2Other)
+      end
+
+      context 'when interface has no alternative' do
+        it 'fits any alternative' do
+          expect(described_class.find('dummy-interface', '1.3', alternative: 'A')).to eq(DummyInterface)
+          expect(DummyInterface.find('1.3', alternative: 'ANY')).to eq(DummyInterface)
+        end
+      end
+
+      context 'when alternative cannot be found' do
+        it 'raises an error' do
+          expect { described_class.find('dummy-interface', '2.3', alternative: 'ANY') }.to raise_error(Taksi::Registry::InterfaceNotFoundError)
+        end
       end
     end
   end

--- a/spec/lib/interface_spec.rb
+++ b/spec/lib/interface_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe ::Taksi::Interface do
     context 'when looking for an alternative' do
       before do
         class DummyInterfaceV2
-          include ::Taksi::Interface.new('dummy-interface', '~> 2.0', alternatives: ['A', 'B'])
+          include ::Taksi::Interface.new('dummy-interface', '~> 2.0', alternatives: %w[A B])
 
           add DummyComponent, with: :dummy_data
 

--- a/spec/lib/interface_spec.rb
+++ b/spec/lib/interface_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe ::Taksi::Interface do
                                          {
                                            name: 'dummy/component',
                                            identifier: 'component$0',
+                                           requires_data: true,
                                            content: {
                                              title: nil
                                            }


### PR DESCRIPTION
The new field `require_data` was added to the component protocol. The objective is make possible for the frontend predict which components will be receiving data from interface data endpoint. With that, frontend may decide to optimize rendering processes.

Also, this request includes an improvement on spec coverage.