### PR TITLE
Prevent name conflicts on components fields definition

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    taksi (0.2.2)
+    taksi (0.2.3)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ class Components::Users::ProfileResume
   include Taksi::Component.new('users/profile_resume')
 
   content do
-    name Taksi::Dynamic
-    profile_kind Taksi::Static, 'resume'
+    static :profile_kind, 'resume' # same as `field :profile_kind, Taksi::Static`
 
-    details do
-      age Taksi::Dynamic
-      email Taksi::Dynamic
+    dynamic :name
+
+    field :details do
+      field :age Taksi::Dynamic # same as `dynamic :age`
+      field :email Taksi::Dynamic
     end
   end
 end

--- a/lib/taksi/component.rb
+++ b/lib/taksi/component.rb
@@ -73,7 +73,6 @@ module Taksi
       def load_data_from_key_to_object(data, field, obj)
         splitted_full_path = field.key.to_s.split('.')
         setter_key = splitted_full_path.pop
-        splitted_full_path.shift # remove content root key, as it makes no sense in data object
 
         relative_object = splitted_full_path.reduce(obj) do |memo, path_part|
           memo[path_part.to_sym] ||= {}

--- a/lib/taksi/components/field.rb
+++ b/lib/taksi/components/field.rb
@@ -24,19 +24,19 @@ module Taksi
       def key
         return name if parent.nil? || parent.root?
 
-        "#{parent.name}.#{name}"
+        "#{parent.key}.#{name}"
       end
 
       # Fetches the data for in `data` for the current field
       # @return any
       def fetch_from(data)
-        return value.as_json if value.static?
+        return value.as_json if value && value.static?
 
         return data[name] if parent.nil? || parent.root?
 
         parent.fetch_from(data)[name]
       rescue NoMethodError
-        raise NameError, "Couldn't fetch #{key.inspect} from data: #{data.inspect}"
+        raise NameError, "Couldn't fetch #{name.inspect} from data: #{data.inspect}"
       end
 
       # Turns the field into his json representation

--- a/lib/taksi/components/field.rb
+++ b/lib/taksi/components/field.rb
@@ -18,7 +18,6 @@ module Taksi
         @nested_fields = []
 
         instance_exec(&block) if block_given?
-        @defined = true
       end
 
       def key
@@ -76,16 +75,22 @@ module Taksi
         @value.dynamic?
       end
 
-      def method_missing(name, *args, &block)
-        return super if @defined
-
-        @nested_fields << self.class.new(skeleton, name, *args, parent: self, &block)
+      def field(name, *args, &block)
+        self.class.new(skeleton, name, *args, parent: self, &block).tap do |new_field|
+          @nested_fields << new_field
+        end
       end
 
-      def respond_to_missing?(name, *)
-        return super if @defined
+      def nested(name, &block)
+        field(name, &block)
+      end
 
-        true
+      def static(name, value)
+        field(name, ::Taksi::Values::Static, value)
+      end
+
+      def dynamic(name)
+        field(name, ::Taksi::Values::Dynamic)
       end
     end
   end

--- a/lib/taksi/components/field.rb
+++ b/lib/taksi/components/field.rb
@@ -29,7 +29,7 @@ module Taksi
       # Fetches the data for in `data` for the current field
       # @return any
       def fetch_from(data)
-        return value.as_json if value && value.static?
+        return value.as_json if value&.static?
 
         return data[name] if parent.nil? || parent.root?
 

--- a/lib/taksi/components/field.rb
+++ b/lib/taksi/components/field.rb
@@ -31,11 +31,11 @@ module Taksi
       def fetch_from(data)
         return value.as_json if value&.static?
 
-        return data[name] if parent.nil? || parent.root?
+        return data.fetch(name) if parent.nil? || parent.root?
 
-        parent.fetch_from(data)[name]
-      rescue NoMethodError
-        raise NameError, "Couldn't fetch #{name.inspect} from data: #{data.inspect}"
+        parent.fetch_from(data).fetch(name)
+      rescue ::KeyError
+        raise ::KeyError, "Couldn't fetch #{key.inspect} from data: #{data.inspect}"
       end
 
       # Turns the field into his json representation

--- a/lib/taksi/registry.rb
+++ b/lib/taksi/registry.rb
@@ -4,6 +4,8 @@ module Taksi
   class Registry
     include ::Singleton
 
+    NAME_REGEX = /^[a-z\-\_\/]{1,80}$/i
+
     class << self
       extend ::Forwardable
 
@@ -18,6 +20,8 @@ module Taksi
     end
 
     def add(klass, name)
+      raise StandardError, "Invalid interface name '#{name}', it must to match regex '#{NAME_REGEX.inspect}'" unless name.to_s.match?(NAME_REGEX)
+
       sym_name = name.to_sym
 
       @interfaces[sym_name] ||= []

--- a/lib/taksi/registry.rb
+++ b/lib/taksi/registry.rb
@@ -4,7 +4,7 @@ module Taksi
   class Registry
     include ::Singleton
 
-    NAME_REGEX = /^[a-z\-\_\/]{1,80}$/i
+    NAME_REGEX = %r{^[a-z\-_/]{1,80}$}i
 
     class << self
       extend ::Forwardable
@@ -20,7 +20,10 @@ module Taksi
     end
 
     def add(klass, name)
-      raise StandardError, "Invalid interface name '#{name}', it must to match regex '#{NAME_REGEX.inspect}'" unless name.to_s.match?(NAME_REGEX)
+      unless name.to_s.match?(NAME_REGEX)
+        raise StandardError,
+              "Invalid interface name '#{name}', it must to match regex '#{NAME_REGEX.inspect}'"
+      end
 
       sym_name = name.to_sym
 

--- a/lib/taksi/values/dynamic.rb
+++ b/lib/taksi/values/dynamic.rb
@@ -3,18 +3,11 @@
 module Taksi
   module Values
     class Dynamic
-      attr_reader :component, :name, :field
+      attr_reader :component, :name
 
-      def initialize(component, name, field = nil)
+      def initialize(component, name)
         @component = component
         @name = name
-        @field = field
-      end
-
-      def path
-        return field if field
-
-        "#{component.id}.#{name}"
       end
 
       def as_json

--- a/lib/taksi/version.rb
+++ b/lib/taksi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Taksi
-  VERSION = '0.2.2'
+  VERSION = '0.2.3'
 end

--- a/spec/lib/component_spec.rb
+++ b/spec/lib/component_spec.rb
@@ -48,9 +48,8 @@ RSpec.describe ::Taksi::Component do
     before do
       class DummyComponent
         content do
-          type ::Taksi::Static, 'dummy_static_value'
-          title ::Taksi::Dynamic, 'dynamic_value.path'
-          # value ::Taksi::Parameter, 'dummy_parameter'
+          field :type, ::Taksi::Static, 'dummy_static_value'
+          field :title, ::Taksi::Dynamic, 'dynamic_value.path'
         end
       end
     end
@@ -73,15 +72,15 @@ RSpec.describe ::Taksi::Component do
     before do
       class DummyComponent
         content do
-          title ::Taksi::Dynamic
+          field :title, ::Taksi::Dynamic
 
-          first_level do
-            type ::Taksi::Static, 'dummy_static_value'
-            title ::Taksi::Dynamic
+          field :first_level do
+            field :type, ::Taksi::Static, 'dummy_static_value'
+            field :title, ::Taksi::Dynamic
 
-            second_level do
-              again ::Taksi::Static, 'dummy_static_value'
-              other ::Taksi::Dynamic
+            field :second_level do
+              static :again, 'dummy_static_value'
+              dynamic :other
             end
           end
         end

--- a/spec/lib/component_spec.rb
+++ b/spec/lib/component_spec.rb
@@ -127,16 +127,16 @@ RSpec.describe ::Taksi::Component do
 
       it 'fetches data correctly' do
         expect(subject.content_for(interface.new)).to eq({
-          title: nil,
-          first_level: {
-            type: 'dummy_static_value',
-            title: 'Dynamic data',
-            second_level: {
-              again: 'dummy_static_value',
-              other: 'More dynamic data'
-            }
-          }
-        })
+                                                           title: nil,
+                                                           first_level: {
+                                                             type: 'dummy_static_value',
+                                                             title: 'Dynamic data',
+                                                             second_level: {
+                                                               again: 'dummy_static_value',
+                                                               other: 'More dynamic data'
+                                                             }
+                                                           }
+                                                         })
       end
     end
   end

--- a/spec/lib/component_spec.rb
+++ b/spec/lib/component_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe ::Taksi::Component do
       class DummyComponent
         content do
           field :type, ::Taksi::Static, 'dummy_static_value'
-          field :title, ::Taksi::Dynamic, 'dynamic_value.path'
+          field :title, ::Taksi::Dynamic
         end
       end
     end
@@ -114,6 +114,7 @@ RSpec.describe ::Taksi::Component do
         class DummyInterface
           def datasource
             {
+              title: 'First dynamic data',
               first_level: {
                 title: 'Dynamic data',
                 second_level: {
@@ -127,7 +128,7 @@ RSpec.describe ::Taksi::Component do
 
       it 'fetches data correctly' do
         expect(subject.content_for(interface.new)).to eq({
-                                                           title: nil,
+                                                           title: 'First dynamic data',
                                                            first_level: {
                                                              type: 'dummy_static_value',
                                                              title: 'Dynamic data',

--- a/spec/lib/components/field_spec.rb
+++ b/spec/lib/components/field_spec.rb
@@ -50,4 +50,64 @@ RSpec.describe ::Taksi::Components::Field do
       end
     end
   end
+
+  describe '#field' do
+  subject { described_class.new(skeleton, key) { } }
+
+    context 'when static' do
+      it 'created a sub field' do
+        new_field = subject.field(:name, ::Taksi::Values::Static, 'static')
+
+        expect(new_field).to be_kind_of(::Taksi::Components::Field)
+        expect(new_field.name).to eq(:name)
+        expect(new_field.value).to be_kind_of(Taksi::Values::Static)
+        expect(new_field.value.value).to eq('static')
+      end
+
+      it 'works the same from shortcut' do
+        new_field = subject.static(:name, 'static')
+
+        expect(new_field).to be_kind_of(::Taksi::Components::Field)
+        expect(new_field.name).to eq(:name)
+        expect(new_field.value).to be_kind_of(Taksi::Values::Static)
+        expect(new_field.value.value).to eq('static')
+      end
+    end
+
+    context 'when dynamic' do
+      it 'created a sub field' do
+        new_field = subject.field(:name, ::Taksi::Values::Dynamic)
+
+        expect(new_field).to be_kind_of(::Taksi::Components::Field)
+        expect(new_field.name).to eq(:name)
+        expect(new_field.value).to be_kind_of(Taksi::Values::Dynamic)
+      end
+
+      it 'works the same from shortcut' do
+        new_field = subject.dynamic(:name)
+
+        expect(new_field).to be_kind_of(::Taksi::Components::Field)
+        expect(new_field.name).to eq(:name)
+        expect(new_field.value).to be_kind_of(Taksi::Values::Dynamic)
+      end
+    end
+
+    context 'when nested' do
+      it 'created a sub field' do
+        new_field = subject.field(:name) { static(:nested_field, 'nested_value') }
+
+        expect(new_field).to be_kind_of(::Taksi::Components::Field)
+        expect(new_field.name).to eq(:name)
+        expect(new_field.value).to eq(nil)
+      end
+
+      it 'works the same from shortcut' do
+        new_field = subject.nested(:name) { static(:nested_field, 'nested_value') }
+
+        expect(new_field).to be_kind_of(::Taksi::Components::Field)
+        expect(new_field.name).to eq(:name)
+        expect(new_field.value).to eq(nil)
+      end
+    end
+  end
 end

--- a/spec/lib/components/field_spec.rb
+++ b/spec/lib/components/field_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe ::Taksi::Components::Field do
   end
 
   describe '#field' do
-  subject { described_class.new(skeleton, key) { } }
+    subject { described_class.new(skeleton, key) {} }
 
     context 'when static' do
       it 'created a sub field' do

--- a/spec/lib/components/field_spec.rb
+++ b/spec/lib/components/field_spec.rb
@@ -26,19 +26,11 @@ RSpec.describe ::Taksi::Components::Field do
   end
 
   context 'when with dynamic fields' do
-    let(:argument) { [::Taksi::Dynamic, 'dynamic_path'] }
+    let(:argument) { [::Taksi::Dynamic] }
 
     context '#as_json' do
       it 'serializes correctly' do
         expect(subject.as_json).to eq({dummy: nil})
-      end
-
-      context 'with empty path' do
-        let(:argument) { [::Taksi::Dynamic] }
-
-        it 'creates a parameter path' do
-          expect(subject.as_json).to eq({dummy: nil})
-        end
       end
     end
 
@@ -47,6 +39,12 @@ RSpec.describe ::Taksi::Components::Field do
 
       it 'return the related data to the key' do
         expect(subject.fetch_from(data)).to eq('the_right_data')
+      end
+
+      context 'when data for field do not exists' do
+        it 'fails with error' do
+          expect { subject.fetch_from({}) }.to raise_error(KeyError, "Couldn't fetch :dummy from data: {}")
+        end
       end
     end
   end

--- a/spec/lib/interface_spec.rb
+++ b/spec/lib/interface_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ::Taksi::Interface do
       include ::Taksi::Component.new('dummy/component')
 
       content do
-        title Taksi::Dynamic
+        field :title, Taksi::Dynamic
       end
     end
 

--- a/spec/lib/registry_spec.rb
+++ b/spec/lib/registry_spec.rb
@@ -8,9 +8,8 @@ RSpec.describe ::Taksi::Registry do
   describe '#add' do
     context 'with an invalid interface name' do
       it 'fails with error messsage' do
-        expect { subject.add(Class, 'INVALID.NAME') }.to raise_error(StandardError, "Invalid interface name 'INVALID.NAME', it must to match regex '/^[a-z\\-\\_\\/]{1,80}$/i'")
+        expect { subject.add(Class, 'INVALID.NAME') }.to raise_error(StandardError, "Invalid interface name 'INVALID.NAME', it must to match regex '/^[a-z\\-_\\/]{1,80}$/i'")
       end
     end
   end
-
 end

--- a/spec/lib/registry_spec.rb
+++ b/spec/lib/registry_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ::Taksi::Registry do
+  subject { described_class.instance }
+
+  describe '#add' do
+    context 'with an invalid interface name' do
+      it 'fails with error messsage' do
+        expect { subject.add(Class, 'INVALID.NAME') }.to raise_error(StandardError, "Invalid interface name 'INVALID.NAME', it must to match regex '/^[a-z\\-\\_\\/]{1,80}$/i'")
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Prevent name conflicts on components fields definition by stopping using method_missing to dynamic declarations.
 - Also, added spec coverage up to 100%.