### PR TITLE
Make interfaces accept custom data to help build dynamic information

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    taksi (0.2.3)
+    taksi (0.2.4)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/taksi/interface.rb
+++ b/lib/taksi/interface.rb
@@ -67,6 +67,7 @@ module Taksi
 
       def initialize(**options)
         @options = options.freeze
+        super()
       end
 
       def skeleton

--- a/lib/taksi/interface.rb
+++ b/lib/taksi/interface.rb
@@ -63,6 +63,12 @@ module Taksi
     end
 
     module InstanceMethods
+      attr_reader :options
+
+      def initialize(**options)
+        @options = options.freeze
+      end
+
       def skeleton
         self.class.skeleton
       end

--- a/lib/taksi/version.rb
+++ b/lib/taksi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Taksi
-  VERSION = '0.2.3'
+  VERSION = '0.2.4'
 end

--- a/spec/lib/interface_spec.rb
+++ b/spec/lib/interface_spec.rb
@@ -149,5 +149,32 @@ RSpec.describe ::Taksi::Interface do
         }
       ])
     end
+
+    context 'when pass options to interface' do
+      subject { DummyInterface.new(**options) }
+
+      let(:options) { {custom_option_data: 'custom_option_data_value'} }
+
+      before do
+        class DummyInterface
+          def dummy_data
+            {title: options[:custom_option_data]}
+          end
+        end
+      end
+
+      it 'returns the interface data' do
+        interface_data = subject.data
+
+        expect(interface_data).to eq([
+          {
+            identifier: 'component$0',
+            content: {
+              title: 'custom_option_data_value'
+            }
+          }
+        ])
+      end
+    end
   end
 end


### PR DESCRIPTION
Make interfaces accept custom data to help build dynamic information.

This creates a door to access custom data (example from requests) inside de data method, just like this:

```ruby
class DummyInterface
  include ::Taksi::Interface.new('dummy-interface', '~> 1.0')

  add DummyComponent, with: :dummy_data

  def dummy_data
    {title: options[:custom_option_data]}
  end
end

DummyInterface.new(custom_option_data: 'custom_option_data_value')
```

